### PR TITLE
fix: do not enforce users to write "enabled = true"

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -165,7 +165,7 @@ spotbugs {
 }
 spotbugsMain {
     reports {
-        text.enabled = true
+        text {}
     }
 }
 """

--- a/src/main/java/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/java/com/github/spotbugs/snom/SpotBugsReport.java
@@ -64,7 +64,7 @@ public abstract class SpotBugsReport
   @Override
   @Input
   public boolean isEnabled() {
-    return isEnabled.getOrElse(Boolean.FALSE);
+    return isEnabled.getOrElse(Boolean.TRUE);
   }
 
   @Override


### PR DESCRIPTION
By default all reports are disabled, then when user specify the report clearly
in the configuration, their intent is quite clear: they want to use that.
So stop asking them adding "enabled = true" by making it default value.