### PR TITLE
ci: disable commit comment lint for github-pages-deploy-action

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -14,8 +14,10 @@ jobs:
         with:
           java-version: 11
       - name: Generate Groovydoc
-        run: ./gradlew groovydoc
-      - name: Build and Deploy
+        run: |
+          ./gradlew groovydoc
+          rm .git/hooks/commit-msg
+      - name: Deploy
         uses: JamesIves/github-pages-deploy-action@c74c1d2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this action does not provide configuration to change the commit comment
so disable commit lint by deleting the hook script.