### PR TITLE
Make getSpotbugsClasspath() return FileCollection

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -88,7 +88,7 @@ dependencies {
 
         then:
         assertEquals(TaskOutcome.SUCCESS, result.task(":classes").outcome)
-        assertTrue(result.output.contains("spotbugs-4.0.0-beta4.jar"))
+        assertTrue(result.output.contains("SpotBugs 4.0.0-beta4"))
     }
 
     def "can skip analysis when no class file we have"() {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.util.GradleVersion;
 
 public class SpotBugsPlugin implements Plugin<Project> {
   public static final String CONFIG_NAME = "spotbugs";
+  public static final String SLF4J_CONFIG_NAME = "spotbugsSlf4j";
   public static final String EXTENSION_NAME = "spotbugs";
 
   /**
@@ -77,7 +78,7 @@ public class SpotBugsPlugin implements Plugin<Project> {
     Configuration spotbugsSlf4j =
         project
             .getConfigurations()
-            .create("spotbugsSlf4j")
+            .create(SLF4J_CONFIG_NAME)
             .setDescription("configuration for the SLF4J provider to run SpotBugs")
             .setVisible(false)
             .setTransitive(true);

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -328,19 +328,11 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
 
     @NonNull
     @Internal
-    Set<File> getSpotbugsClasspath() {
+    FileCollection getSpotbugsClasspath() {
         Configuration config = getProject().getConfigurations().getByName(SpotBugsPlugin.CONFIG_NAME)
-        Configuration spotbugsSlf4j = getProject().getConfigurations().getByName("spotbugsSlf4j")
+        Configuration spotbugsSlf4j = getProject().getConfigurations().getByName(SpotBugsPlugin.SLF4J_CONFIG_NAME)
 
-        Set<File> spotbugsJar = config.getFiles()
-        log.info("SpotBugs jar file: {}", spotbugsJar)
-        Set<File> slf4jJar = spotbugsSlf4j.getFiles()
-        log.info("SLF4J provider jar file: {}", slf4jJar)
-
-        Set<File> jarOnClasspath = new HashSet<>()
-        jarOnClasspath.addAll(spotbugsJar)
-        jarOnClasspath.addAll(slf4jJar)
-        return jarOnClasspath
+        return getProject().files(config, spotbugsSlf4j)
     }
 
     @Nullable


### PR DESCRIPTION
 - Lazily resolve `spotbugs` and `spotbugsSlf4j` configurations
 - Extracted `spotbugsSlf4j` name to constant
 - Tweak test condition since `--info`-level logging no longer dumps classpath