### PR TITLE
fix: miscellaneous conversion of Provider<File> to RegularFileProvide…

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gradle: ['5.6', '6.0']
+        gradle: ['5.6', '6.0', '6.1']
     steps:
     - uses: actions/checkout@722adc6
       with:

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -26,9 +26,7 @@ task functionalTest(type: Test) {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     mustRunAfter test
-    options {
-        systemProperty "snom.test.functional.gradle", System.getProperty("snom.test.functional.gradle")
-    }
+    systemProperty 'snom.test.functional.gradle', System.getProperty('snom.test.functional.gradle', gradle.gradleVersion)
 }
 
 check.dependsOn functionalTest

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach
 import spock.lang.Specification
 
 import org.gradle.testkit.runner.GradleRunner
-import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -74,8 +73,7 @@ public class Foo {
         assertFalse(reportsDir.isDirectory())
     }
 
-    @Unroll
-    def "can generate spotbugs.txt: Gradle #gradleVersion"() {
+    def "can generate spotbugs.txt"() {
         buildFile << """
 spotbugsMain {
     reports {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import spock.lang.Specification
 
 import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -73,7 +74,8 @@ public class Foo {
         assertFalse(reportsDir.isDirectory())
     }
 
-    def "can generate spotbugs.txt"() {
+    @Unroll
+    def "can generate spotbugs.txt: Gradle #gradleVersion"() {
         buildFile << """
 spotbugsMain {
     reports {
@@ -83,7 +85,7 @@ spotbugsMain {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(rootDir)
-                .withArguments('spotbugsMain')
+                .withArguments('spotbugsMain', '-is')
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -94,6 +94,72 @@ spotbugsMain {
         assertTrue(report.isFile())
     }
 
+    def "can generate spotbugs.txt in configured buildDir"() {
+        buildFile << """
+spotbugsMain {
+    reports {
+        text.enabled = true
+    }
+}
+buildDir = 'new-build-dir'
+"""
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.txt").toFile()
+        assertTrue(report.isFile())
+    }
+
+    def "can generate spotbugs.html in configured buildDir"() {
+        buildFile << """
+spotbugsMain {
+    reports {
+        html.enabled = true
+    }
+}
+buildDir = 'new-build-dir'
+"""
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.html").toFile()
+        assertTrue(report.isFile())
+    }
+
+    def "can generate spotbugs.xml in configured buildDir"() {
+        buildFile << """
+spotbugsMain {
+    reports {
+        xml.enabled = true
+    }
+}
+buildDir = 'new-build-dir'
+"""
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.xml").toFile()
+        assertTrue(report.isFile())
+    }
+
     def "can generate spotbugs.html"() {
         buildFile << """
 spotbugsMain {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -14,7 +14,9 @@
 package com.github.spotbugs.snom;
 
 import edu.umd.cs.findbugs.annotations.NonNull
-import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty;
 
 import javax.inject.Inject;
 import org.gradle.api.Project;
@@ -82,7 +84,7 @@ class SpotBugsExtension {
      * <p>Note that each {@link SpotBugsTask} creates own sub-directory in this directory.</p>
      */
     @NonNull
-    final Property<File> reportsDir;
+    final DirectoryProperty reportsDir;
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -92,7 +94,7 @@ class SpotBugsExtension {
      * <p>See also <a href="https://spotbugs.readthedocs.io/en/stable/filter.html">SpotBugs Manual about Filter file</a>.</p>
      */
     @NonNull
-    final Property<File> includeFilter;
+    final RegularFileProperty includeFilter;
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -102,7 +104,7 @@ class SpotBugsExtension {
      * <p>See also <a href="https://spotbugs.readthedocs.io/en/stable/filter.html">SpotBugs Manual about Filter file</a>.</p>
      */
     @NonNull
-    final Property<File> excludeFilter;
+    final RegularFileProperty excludeFilter;
     /**
      * Property to specify the target classes for analysis. Default value is empty that means all classes are analyzed.
      */
@@ -146,15 +148,14 @@ class SpotBugsExtension {
         effort = objects.property(Effort);
         visitors = objects.listProperty(String);
         omitVisitors = objects.listProperty(String);
-        reportsDir = objects.property(File)
-        includeFilter = objects.property(File);
-        excludeFilter = objects.property(File);
+        reportsDir = objects.directoryProperty()
+        includeFilter = objects.fileProperty()
+        excludeFilter = objects.fileProperty()
         onlyAnalyze = objects.listProperty(String);
         projectName = objects.property(String);
         release = objects.property(String);
+        reportsDir.set(project.layout.buildDirectory.dir('reports/spotbugs'))
         project.afterEvaluate( { p ->
-            File reports = new File(project.buildDir, "reports")
-            reportsDir.convention(new File(reports, "spotbugs"))
             projectName.convention(p.getName());
             release.convention(p.getVersion().toString());
         });

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -154,10 +154,10 @@ class SpotBugsExtension {
         onlyAnalyze = objects.listProperty(String);
         projectName = objects.property(String);
         release = objects.property(String);
-        reportsDir.set(project.layout.buildDirectory.dir('reports/spotbugs'))
         project.afterEvaluate( { p ->
             projectName.convention(p.getName());
             release.convention(p.getVersion().toString());
+            reportsDir.convention(project.layout.buildDirectory.dir('reports/spotbugs'))
         });
         jvmArgs = objects.listProperty(String);
         extraArgs = objects.listProperty(String);

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -39,12 +39,14 @@ public abstract class SpotBugsReport
 {
   private final RegularFileProperty destination;
   private final Property<Boolean> isEnabled;
+  private final Property<Boolean> isRequired;
   private final SpotBugsTask task;
 
   @Inject
   public SpotBugsReport(ObjectFactory objects, SpotBugsTask task) {
     this.destination = objects.fileProperty();
     this.isEnabled = objects.property(Boolean.class);
+    this.isRequired = objects.property(Boolean.class).value(Boolean.TRUE);
     this.task = task;
   }
 
@@ -57,10 +59,22 @@ public abstract class SpotBugsReport
     return destination.get().getAsFile();
   }
 
+  // @Override // New API from 6.1; see https://github.com/gradle/gradle/issues/11923
+  @OutputFile
+  public RegularFileProperty getOutputLocation() {
+    return destination;
+  }
+
   @Override
   @Internal("This property returns always same value")
   public OutputType getOutputType() {
     return OutputType.FILE;
+  }
+
+  // @Override // New API from 6.1; see https://github.com/gradle/gradle/issues/11923
+  @Input
+  public Property<Boolean> getRequired() {
+    return isRequired;
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -37,13 +38,13 @@ public abstract class SpotBugsReport
     implements SingleFileReport,
         CustomizableHtmlReport // to expose CustomizableHtmlReport#setStylesheet to build script
 {
-  private final Property<File> destination;
+  private final RegularFileProperty destination;
   private final Property<Boolean> isEnabled;
   private final SpotBugsTask task;
 
   @Inject
   public SpotBugsReport(ObjectFactory objects, SpotBugsTask task) {
-    this.destination = objects.property(File.class);
+    this.destination = objects.fileProperty();
     this.isEnabled = objects.property(Boolean.class);
     this.task = task;
   }
@@ -54,7 +55,7 @@ public abstract class SpotBugsReport
   @Override
   @OutputFile
   public File getDestination() {
-    return destination.getOrNull();
+    return destination.get().getAsFile();
   }
 
   @Override
@@ -86,7 +87,7 @@ public abstract class SpotBugsReport
 
   @Override
   public void setDestination(Provider<File> provider) {
-    destination.set(provider);
+    destination.set(this.task.getProject().getLayout().file(provider));
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -19,6 +19,7 @@ import groovy.lang.Closure;
 import java.io.File;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -35,12 +36,12 @@ public abstract class SpotBugsReport
     implements SingleFileReport,
         CustomizableHtmlReport // to expose CustomizableHtmlReport#setStylesheet to build script
 {
-  private final Property<File> destination;
+  private final RegularFileProperty destination;
   private final Property<Boolean> isEnabled;
   private final SpotBugsTask task;
 
   public SpotBugsReport(ObjectFactory objects, SpotBugsTask task) {
-    this.destination = objects.property(File.class);
+    this.destination = objects.fileProperty();
     this.isEnabled = objects.property(Boolean.class);
     this.task = task;
   }
@@ -51,7 +52,7 @@ public abstract class SpotBugsReport
   @Override
   @OutputFile
   public File getDestination() {
-    return destination.get();
+    return destination.get().getAsFile();
   }
 
   @Override
@@ -83,7 +84,7 @@ public abstract class SpotBugsReport
 
   @Override
   public void setDestination(Provider<File> provider) {
-    destination.set(provider);
+    destination.fileProvider(provider);
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -19,7 +19,8 @@ import groovy.lang.Closure;
 import java.io.File;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.gradle.api.file.RegularFileProperty;
+import javax.inject.Inject;
+
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -36,12 +37,13 @@ public abstract class SpotBugsReport
     implements SingleFileReport,
         CustomizableHtmlReport // to expose CustomizableHtmlReport#setStylesheet to build script
 {
-  private final RegularFileProperty destination;
+  private final Property<File> destination;
   private final Property<Boolean> isEnabled;
   private final SpotBugsTask task;
 
+  @Inject
   public SpotBugsReport(ObjectFactory objects, SpotBugsTask task) {
-    this.destination = objects.fileProperty();
+    this.destination = objects.property(File.class);
     this.isEnabled = objects.property(Boolean.class);
     this.task = task;
   }
@@ -52,7 +54,7 @@ public abstract class SpotBugsReport
   @Override
   @OutputFile
   public File getDestination() {
-    return destination.get().getAsFile();
+    return destination.getOrNull();
   }
 
   @Override
@@ -84,7 +86,7 @@ public abstract class SpotBugsReport
 
   @Override
   public void setDestination(Provider<File> provider) {
-    destination.fileProvider(provider);
+    destination.set(provider);
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -254,11 +254,11 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
                 SpotBugsReport, {name ->
                     switch (name) {
                         case "html":
-                            return new SpotBugsHtmlReport(objects, this);
+                            return objects.newInstance(SpotBugsHtmlReport.class, objects, this)
                         case "xml":
-                            return new SpotBugsXmlReport(objects, this);
+                            return objects.newInstance(SpotBugsXmlReport.class, objects, this)
                         case "text":
-                            return new SpotBugsTextReport(objects, this);
+                            return objects.newInstance(SpotBugsTextReport.class, objects, this)
                         default:
                             throw new InvalidUserDataException(name + " is invalid as the report name");
                     }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -21,6 +21,8 @@ import com.github.spotbugs.snom.internal.SpotBugsXmlReport;
 import edu.umd.cs.findbugs.annotations.NonNull
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.OverrideMustInvoke
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SkipWhenEmpty
 
@@ -47,6 +49,8 @@ import org.gradle.util.ClosureBackedAction;
 import org.gradle.workers.WorkerExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory
+
+import javax.inject.Inject
 
 /**
  * The Gradle task to run the SpotBugs analysis. All properties are optional.
@@ -124,7 +128,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      */
     @Internal("Refer the destination of each report instead.")
     @NonNull
-    final Property<File> reportsDir;
+    final DirectoryProperty reportsDir;
 
     /**
      * Property to specify which report you need.
@@ -147,7 +151,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
     @NonNull
-    final Property<File> includeFilter;
+    final RegularFileProperty includeFilter;
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -160,7 +164,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
     @NonNull
-    final Property<File> excludeFilter;
+    final RegularFileProperty excludeFilter;
     /**
      * Property to specify the target classes for analysis. Default value is empty that means all classes are analyzed.
      */
@@ -234,6 +238,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         getClassDirs().asFileTree
     }
 
+    @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {
         this.workerExecutor = Objects.requireNonNull(workerExecutor);
 
@@ -243,7 +248,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         effort = objects.property(Effort);
         visitors = objects.listProperty(String);
         omitVisitors = objects.listProperty(String);
-        reportsDir = objects.property(File);
+        reportsDir = objects.directoryProperty()
         reports =
                 objects.domainObjectContainer(
                 SpotBugsReport, {name ->
@@ -258,8 +263,8 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
                             throw new InvalidUserDataException(name + " is invalid as the report name");
                     }
                 });
-        includeFilter = objects.property(File);
-        excludeFilter = objects.property(File);
+        includeFilter = objects.fileProperty()
+        excludeFilter = objects.fileProperty()
         onlyAnalyze = objects.listProperty(String);
         projectName = objects.property(String);
         release = objects.property(String);
@@ -283,7 +288,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         visitors.set(extension.visitors)
         omitVisitors.set(extension.omitVisitors)
         // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}"
-        reportsDir.set(extension.reportsDir.map({dir -> new File(dir, getName())}))
+        reportsDir.set(extension.reportsDir.dir(getName()))
         includeFilter.set(extension.includeFilter)
         excludeFilter.set(extension.excludeFilter)
         onlyAnalyze.set(extension.onlyAnalyze)

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -19,13 +19,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.util.Optional;
+import javax.inject.Inject;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
-
-import javax.inject.Inject;
 
 public abstract class SpotBugsHtmlReport extends SpotBugsReport {
   private final Property<TextResource> stylesheet;

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -31,7 +31,7 @@ public class SpotBugsHtmlReport extends SpotBugsReport {
   public SpotBugsHtmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.html"
-    setDestination(task.getReportsDir().map(dir -> new File(dir, "spotbugs.html")));
+    setDestination(task.getReportsDir().file("spotbugs.html").get().getAsFile());
     stylesheet = objects.property(TextResource.class);
     stylesheetPath = objects.property(String.class);
   }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -25,10 +25,13 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
 
-public class SpotBugsHtmlReport extends SpotBugsReport {
+import javax.inject.Inject;
+
+public abstract class SpotBugsHtmlReport extends SpotBugsReport {
   private final Property<TextResource> stylesheet;
   private final Property<String> stylesheetPath;
 
+  @Inject
   public SpotBugsHtmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.html"

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.util.Optional;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
@@ -31,7 +32,7 @@ public class SpotBugsHtmlReport extends SpotBugsReport {
   public SpotBugsHtmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.html"
-    setDestination(task.getReportsDir().file("spotbugs.html").get().getAsFile());
+    setDestination(task.getReportsDir().file("spotbugs.html").map(RegularFile::getAsFile));
     stylesheet = objects.property(TextResource.class);
     stylesheetPath = objects.property(String.class);
   }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -79,11 +79,11 @@ public abstract class SpotBugsRunner {
     }
     if (task.getIncludeFilter().isPresent() && task.getIncludeFilter().get() != null) {
       args.add("-include");
-      args.add(task.getIncludeFilter().get().getAbsolutePath());
+      args.add(task.getIncludeFilter().get().getAsFile().getAbsolutePath());
     }
     if (task.getExcludeFilter().isPresent() && task.getExcludeFilter().get() != null) {
       args.add("-exclude");
-      args.add(task.getExcludeFilter().get().getAbsolutePath());
+      args.add(task.getExcludeFilter().get().getAsFile().getAbsolutePath());
     }
     if (task.getOnlyAnalyze().isPresent() && !task.getOnlyAnalyze().get().isEmpty()) {
       args.add("-onlyAnalyze");

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskForJava.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskForJava.java
@@ -15,7 +15,6 @@ package com.github.spotbugs.snom.internal;
 
 import com.github.spotbugs.snom.SpotBugsExtension;
 import com.github.spotbugs.snom.SpotBugsTask;
-import java.io.File;
 import java.util.Objects;
 import javax.inject.Inject;
 import org.gradle.api.file.FileCollection;
@@ -42,7 +41,7 @@ class SpotBugsTaskForJava extends SpotBugsTask {
   protected void init(SpotBugsExtension extension) {
     super.init(extension);
     // the default reportsDir is "$buildDir/reports/spotbugs/${sourceSetName}"
-    getReportsDir().set(extension.getReportsDir().map(dir -> new File(dir, sourceSet.getName())));
+    getReportsDir().set(extension.getReportsDir().dir(sourceSet.getName()));
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -17,13 +17,14 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 
 public class SpotBugsTextReport extends SpotBugsReport {
   public SpotBugsTextReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.txt"
-    setDestination(task.getReportsDir().file("spotbugs.txt").get().getAsFile());
+    setDestination(task.getReportsDir().file("spotbugs.txt").map(RegularFile::getAsFile));
   }
 
   @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -16,7 +16,6 @@ package com.github.spotbugs.snom.internal;
 import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.File;
 import java.util.Optional;
 import org.gradle.api.model.ObjectFactory;
 
@@ -24,7 +23,7 @@ public class SpotBugsTextReport extends SpotBugsReport {
   public SpotBugsTextReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.txt"
-    setDestination(task.getReportsDir().map(dir -> new File(dir, "spotbugs.txt")));
+    setDestination(task.getReportsDir().file("spotbugs.txt").get().getAsFile());
   }
 
   @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -17,6 +17,7 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
+
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -20,7 +20,11 @@ import java.util.Optional;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 
-public class SpotBugsTextReport extends SpotBugsReport {
+import javax.inject.Inject;
+
+public abstract class SpotBugsTextReport extends SpotBugsReport {
+
+  @Inject
   public SpotBugsTextReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.txt"

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -17,11 +17,9 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
-
+import javax.inject.Inject;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
-
-import javax.inject.Inject;
 
 public abstract class SpotBugsTextReport extends SpotBugsReport {
 

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -16,7 +16,6 @@ package com.github.spotbugs.snom.internal;
 import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.File;
 import java.util.Optional;
 import org.gradle.api.model.ObjectFactory;
 
@@ -24,7 +23,7 @@ public class SpotBugsXmlReport extends SpotBugsReport {
   public SpotBugsXmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.xml"
-    setDestination(task.getReportsDir().map(dir -> new File(dir, "spotbugs.xml")));
+    setDestination(task.getReportsDir().file("spotbugs.xml").get().getAsFile());
   }
 
   @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -17,10 +17,9 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
+import javax.inject.Inject;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
-
-import javax.inject.Inject;
 
 public abstract class SpotBugsXmlReport extends SpotBugsReport {
 

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -17,13 +17,14 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 
 public class SpotBugsXmlReport extends SpotBugsReport {
   public SpotBugsXmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.xml"
-    setDestination(task.getReportsDir().file("spotbugs.xml").get().getAsFile());
+    setDestination(task.getReportsDir().file("spotbugs.xml").map(RegularFile::getAsFile));
   }
 
   @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -20,7 +20,11 @@ import java.util.Optional;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.model.ObjectFactory;
 
-public class SpotBugsXmlReport extends SpotBugsReport {
+import javax.inject.Inject;
+
+public abstract class SpotBugsXmlReport extends SpotBugsReport {
+
+  @Inject
   public SpotBugsXmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
     // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.xml"


### PR DESCRIPTION
…r and DirectoryProvider

 - This enables configuration of the tasks via Java, avoiding `SpotBugsTask#reports(Closure)`
 - Also add `@Inject` to SpotBugsTask constructor per https://guides.gradle.org/using-the-worker-api/#converting_to_the_worker_api