### PR TITLE
Fix the location of report

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -90,7 +90,7 @@ spotbugsMain {
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.txt").toFile()
+        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.txt").toFile()
         assertTrue(report.isFile())
     }
 
@@ -112,7 +112,7 @@ buildDir = 'new-build-dir'
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.txt").toFile()
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main.txt").toFile()
         assertTrue(report.isFile())
     }
 
@@ -134,7 +134,7 @@ buildDir = 'new-build-dir'
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.html").toFile()
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main.html").toFile()
         assertTrue(report.isFile())
     }
 
@@ -156,7 +156,7 @@ buildDir = 'new-build-dir'
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.xml").toFile()
+        File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main.xml").toFile()
         assertTrue(report.isFile())
     }
 
@@ -178,7 +178,7 @@ spotbugsMain {
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.html").toFile()
+        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html").toFile()
         assertTrue(report.isFile())
         assertTrue(result.getOutput().contains("-html,"))
     }
@@ -211,7 +211,7 @@ spotbugsMain {
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.html").toFile()
+        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html").toFile()
         assertTrue(report.isFile())
         assertTrue(result.getOutput().contains("-html:"))
         // confirm -projectName is working
@@ -241,7 +241,7 @@ spotbugsMain {
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.html").toFile()
+        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html").toFile()
         assertTrue(report.isFile())
         assertTrue(result.getOutput().contains("-html:"))
     }
@@ -263,7 +263,7 @@ spotbugsMain {
 
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
-        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main").resolve("spotbugs.xml").toFile()
+        File report = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.xml").toFile()
         assertTrue(report.isFile())
     }
 
@@ -290,7 +290,7 @@ spotbugsMain {
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         File reportsDir = rootDir.toPath().resolve("build").resolve("spotbugs").toFile();
         assertTrue(reportsDir.isDirectory())
-        File report = reportsDir.toPath().resolve("main").resolve("spotbugs.txt").toFile()
+        File report = reportsDir.toPath().resolve("main.txt").toFile()
         assertTrue(report.isFile())
     }
 

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -287,8 +287,8 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         effort.set(extension.effort)
         visitors.set(extension.visitors)
         omitVisitors.set(extension.omitVisitors)
-        // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}"
-        reportsDir.set(extension.reportsDir.dir(getName()))
+        // the default reportsDir is "$buildDir/reports/spotbugs/"
+        reportsDir.set(extension.reportsDir)
         includeFilter.set(extension.includeFilter)
         excludeFilter.set(extension.excludeFilter)
         onlyAnalyze.set(extension.onlyAnalyze)
@@ -368,5 +368,14 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Input
     boolean getIgnoreFailures() {
         ignoreFailures.get();
+    }
+
+    @Internal
+    String getBaseName() {
+        String prunedName = name.replaceFirst("spotbugs", "")
+        if (prunedName.isEmpty()) {
+            prunedName = task.getName()
+        }
+        return new StringBuilder().append(Character.toLowerCase(prunedName.charAt(0))).append(prunedName.substring(1)).toString()
     }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -33,8 +33,9 @@ public abstract class SpotBugsHtmlReport extends SpotBugsReport {
   @Inject
   public SpotBugsHtmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
-    // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.html"
-    setDestination(task.getReportsDir().file("spotbugs.html").map(RegularFile::getAsFile));
+    // the default reportsDir is "$buildDir/reports/spotbugs/${baseName}.html"
+    setDestination(
+        task.getReportsDir().file(task.getBaseName() + ".html").map(RegularFile::getAsFile));
     stylesheet = objects.property(TextResource.class);
     stylesheetPath = objects.property(String.class);
   }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskForJava.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskForJava.java
@@ -13,7 +13,6 @@
  */
 package com.github.spotbugs.snom.internal;
 
-import com.github.spotbugs.snom.SpotBugsExtension;
 import com.github.spotbugs.snom.SpotBugsTask;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -35,13 +34,6 @@ class SpotBugsTaskForJava extends SpotBugsTask {
   void setSourceSet(SourceSet sourceSet) {
     this.sourceSet = Objects.requireNonNull(sourceSet);
     dependsOn(sourceSet.getClassesTaskName());
-  }
-
-  @Override
-  protected void init(SpotBugsExtension extension) {
-    super.init(extension);
-    // the default reportsDir is "$buildDir/reports/spotbugs/${sourceSetName}"
-    getReportsDir().set(extension.getReportsDir().dir(sourceSet.getName()));
   }
 
   @Override

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -26,8 +26,9 @@ public abstract class SpotBugsTextReport extends SpotBugsReport {
   @Inject
   public SpotBugsTextReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
-    // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.txt"
-    setDestination(task.getReportsDir().file("spotbugs.txt").map(RegularFile::getAsFile));
+    // the default reportsDir is "$buildDir/reports/spotbugs/${baseName}.txt"
+    setDestination(
+        task.getReportsDir().file(task.getBaseName() + ".txt").map(RegularFile::getAsFile));
   }
 
   @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -26,8 +26,9 @@ public abstract class SpotBugsXmlReport extends SpotBugsReport {
   @Inject
   public SpotBugsXmlReport(ObjectFactory objects, SpotBugsTask task) {
     super(objects, task);
-    // the default reportsDir is "$buildDir/reports/spotbugs/${taskName}/spotbugs.xml"
-    setDestination(task.getReportsDir().file("spotbugs.xml").map(RegularFile::getAsFile));
+    // the default reportsDir is "$buildDir/reports/spotbugs/${baseName}.xml"
+    setDestination(
+        task.getReportsDir().file(task.getBaseName() + ".xml").map(RegularFile::getAsFile));
   }
 
   @NonNull


### PR DESCRIPTION
Legacy plugin locates report at "build/reports/spotbugs/main.text",  "build/reports/spotbugs/test.html" and so on. No need to make a subdirectory inside `$buildDir/reports/spotbugs`.

It also uses `.text` extension for text report, but we do not keep this behavior because `.txt` is more common.