### PR TITLE
fix: configuration name for external plugins

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.util.GradleVersion;
 
 public class SpotBugsPlugin implements Plugin<Project> {
   public static final String CONFIG_NAME = "spotbugs";
+  public static final String PLUGINS_CONFIG_NAME = "spotbugsPlugins";
   public static final String SLF4J_CONFIG_NAME = "spotbugsSlf4j";
   public static final String EXTENSION_NAME = "spotbugs";
 
@@ -95,8 +96,8 @@ public class SpotBugsPlugin implements Plugin<Project> {
   private Configuration createPluginConfiguration(Project project) {
     return project
         .getConfigurations()
-        .create("spotbugsPlugin")
-        .setDescription("configuration for the SpotBugs plugin")
+        .create(PLUGINS_CONFIG_NAME)
+        .setDescription("configuration for the external SpotBugs plugins")
         .setVisible(false)
         .setTransitive(true);
   }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -342,7 +342,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @NonNull
     @Internal
     Set<File> getPluginJar() {
-        return getProject().getConfigurations().getByName("spotbugsPlugin").getFiles()
+        return getProject().getConfigurations().getByName(SpotBugsPlugin.PLUGINS_CONFIG_NAME).getFiles()
     }
 
     @NonNull


### PR DESCRIPTION
It's just a typo. Now it's backwards-compatible and matches the documentation.