### PR TITLE
Support dynamic task generation when source set is added by user

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
@@ -15,7 +15,6 @@ package com.github.spotbugs.snom.internal;
 
 import com.android.build.gradle.tasks.AndroidJavaCompile;
 import com.github.spotbugs.snom.SpotBugsTask;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Action;
@@ -23,7 +22,6 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.util.GUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,52 +29,40 @@ import org.slf4j.LoggerFactory;
 public class SpotBugsTaskFactory {
   private final Logger log = LoggerFactory.getLogger(SpotBugsTaskFactory.class);
 
-  public List<Provider<SpotBugsTask>> generate(
-      Project project, Action<? super SpotBugsTask> configurationAction) {
-    List<Provider<SpotBugsTask>> tasks = new ArrayList<>();
-    generateForJava(project, tasks, configurationAction);
-    generateForAndroid(project, tasks, configurationAction);
-    return tasks;
+  public void generate(Project project, Action<? super SpotBugsTask> configurationAction) {
+    generateForJava(project, configurationAction);
+    generateForAndroid(project, configurationAction);
   }
 
-  private void generateForJava(
-      Project project,
-      List<Provider<SpotBugsTask>> tasks,
-      Action<? super SpotBugsTask> configurationAction) {
+  private void generateForJava(Project project, Action<? super SpotBugsTask> configurationAction) {
     project
         .getPlugins()
         .withType(JavaBasePlugin.class)
         .configureEach(
             javaBasePlugin -> {
               JavaPluginConvention convention =
-                  project.getConvention().findPlugin(JavaPluginConvention.class);
-              SourceSetContainer sourceSets = convention.getSourceSets();
-              List<Provider<SpotBugsTask>> spotbugsTasks =
-                  sourceSets.stream()
-                      .map(
-                          sourceSet -> {
-                            String name = sourceSet.getTaskName("spotbugs", null);
-                            log.debug("Creating SpotBugsTaskForJava for {}", sourceSet);
-                            return project
-                                .getTasks()
-                                .register(
-                                    name,
-                                    SpotBugsTaskForJava.class,
-                                    task -> {
-                                      task.setSourceSet(sourceSet);
-                                      configurationAction.execute(task);
-                                    });
-                          })
-                      .map(p -> p.map(SpotBugsTask.class::cast))
-                      .collect(Collectors.toList());
-              tasks.addAll(spotbugsTasks);
+                  project.getConvention().getPlugin(JavaPluginConvention.class);
+              convention
+                  .getSourceSets()
+                  .all(
+                      sourceSet -> {
+                        String name = sourceSet.getTaskName("spotbugs", null);
+                        log.debug("Creating SpotBugsTaskForJava for {}", sourceSet);
+                        project
+                            .getTasks()
+                            .register(
+                                name,
+                                SpotBugsTaskForJava.class,
+                                task -> {
+                                  task.setSourceSet(sourceSet);
+                                  configurationAction.execute(task);
+                                });
+                      });
             });
   }
 
   private void generateForAndroid(
-      Project project,
-      List<Provider<SpotBugsTask>> tasks,
-      Action<? super SpotBugsTask> configurationAction) {
+      Project project, Action<? super SpotBugsTask> configurationAction) {
     project
         .getPlugins()
         .withId(
@@ -101,7 +87,6 @@ public class SpotBugsTaskFactory {
                           })
                       .map(p -> p.map(SpotBugsTask.class::cast))
                       .collect(Collectors.toList());
-              tasks.addAll(spotbugsTasks);
             });
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
@@ -15,13 +15,10 @@ package com.github.spotbugs.snom.internal;
 
 import com.android.build.gradle.tasks.AndroidJavaCompile;
 import com.github.spotbugs.snom.SpotBugsTask;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.provider.Provider;
 import org.gradle.util.GUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,25 +65,23 @@ public class SpotBugsTaskFactory {
         .withId(
             "com.android.application",
             plugin -> {
-              List<Provider<SpotBugsTask>> spotbugsTasks =
-                  project.getTasks().withType(AndroidJavaCompile.class).stream()
-                      .map(
-                          task -> {
-                            String name =
-                                GUtil.toLowerCamelCase("spotbugs " + task.getVariantName());
-                            log.debug("Creating SpotBugsTaskForAndroid for {}", task);
-                            return project
-                                .getTasks()
-                                .register(
-                                    name,
-                                    SpotBugsTaskForAndroid.class,
-                                    spotbugsTask -> {
-                                      configurationAction.execute(spotbugsTask);
-                                      spotbugsTask.setTask(task);
-                                    });
-                          })
-                      .map(p -> p.map(SpotBugsTask.class::cast))
-                      .collect(Collectors.toList());
+              project
+                  .getTasks()
+                  .withType(AndroidJavaCompile.class)
+                  .all(
+                      task -> {
+                        String name = GUtil.toLowerCamelCase("spotbugs " + task.getVariantName());
+                        log.debug("Creating SpotBugsTaskForAndroid for {}", task);
+                        project
+                            .getTasks()
+                            .register(
+                                name,
+                                SpotBugsTaskForAndroid.class,
+                                spotbugsTask -> {
+                                  configurationAction.execute(spotbugsTask);
+                                  spotbugsTask.setTask(task);
+                                });
+                      });
             });
   }
 }


### PR DESCRIPTION
When user add source sets by build script, this plugin should generate `spotbugs${sourceSetName}` task dynamically, so user can run and configure the task.

refs #75